### PR TITLE
Dashboard timestamps

### DIFF
--- a/semaphore/dashboards.v1alpha.proto
+++ b/semaphore/dashboards.v1alpha.proto
@@ -13,6 +13,8 @@ message Dashboard {
   message Metadata {
     string name = 1;
     string id = 2;
+    int64 create_time = 3;
+    int64 update_time = 4;
   }
 
   message Spec {


### PR DESCRIPTION
Using simple int64 values for unix timestamps, I think this will cover most of the use cases for us.

The change will be necessary for sem cli integration.