### PR TITLE
feat: add agent name to job API

### DIFF
--- a/semaphore/jobs.v1alpha.proto
+++ b/semaphore/jobs.v1alpha.proto
@@ -101,6 +101,7 @@ message Job {
 
       string ip = 1;
       repeated Port ports = 2;
+      string name = 3;
     }
 
     Result result = 1;


### PR DESCRIPTION
Currently, users can't map a job ID to the self-hosted agent where it ran. Including the agent name in the public job API response would make it possible.

For example, right now, when you do a `sem get job JOB_ID`, you get this:
```yaml
# for a cloud job
status:
  state: FINISHED
  result: PASSED
  agent:
    ip: 138.201.34.123
    ports:
    - name: ssh
      number: 40008

# for a self-hosted job
status:
  state: FINISHED
  result: FAILED
  agent:
    ip: ""
    ports: []
```

We are improving it by including the agent name:

```yaml
# hosted job
status:
  state: FINISHED
  result: PASSED
  agent:
    name: ""
    ip: 138.201.34.123
    ports:
    - name: ssh
      number: 40008

# self-hosted job
status:
  state: FINISHED
  result: FAILED
  agent:
    name: "i-21093021479_00cx72"
    ip: ""
    ports: []
```