### PR TITLE
add create debug job for project

### DIFF
--- a/semaphore/jobs.v1alpha.proto
+++ b/semaphore/jobs.v1alpha.proto
@@ -160,7 +160,7 @@ message CreateDebugJobRequest {
 }
 
 message CreateDebugProjectRequest {
-  string project_id = 1;
+  string project_id_or_name = 1;
   int32 duration = 2; // Duration of debug jobs in minutes
   string machine_type = 3; // machine type to use for debugging
 }

--- a/semaphore/jobs.v1alpha.proto
+++ b/semaphore/jobs.v1alpha.proto
@@ -161,6 +161,6 @@ message CreateDebugJobRequest {
 
 message CreateDebugProjectRequest {
   string project_id = 1;
-  int32 duration = 2; // Duration of debug jobs in minutes, defaults to 60 minutes when set to 0.
-  string machine_type = 3; // machine type to use for debugging; default: e1-standard-2
+  int32 duration = 2; // Duration of debug jobs in minutes
+  string machine_type = 3; // machine type to use for debugging
 }

--- a/semaphore/jobs.v1alpha.proto
+++ b/semaphore/jobs.v1alpha.proto
@@ -10,6 +10,7 @@ service JobsApi {
   rpc GetJobDebugSSHKey(GetJobDebugSSHKeyRequest) returns (JobDebugSSHKey);
   rpc CreateJob(Job) returns (Job);
   rpc CreateDebugJob(CreateDebugJobRequest) returns (Job);
+  rpc CreateDebugProject(CreateDebugProjectRequest) returns (Job);
   rpc StopJob(StopJobRequest) returns (Empty);
 }
 
@@ -155,5 +156,10 @@ message JobDebugSSHKey {
 
 message CreateDebugJobRequest {
   string job_id = 1;
+  int32 duration = 2; // Duration of debug jobs in minutes, defaults to 60 minutes when set to 0.
+}
+
+message CreateDebugProjectRequest {
+  string project_id = 1;
   int32 duration = 2; // Duration of debug jobs in minutes, defaults to 60 minutes when set to 0.
 }

--- a/semaphore/jobs.v1alpha.proto
+++ b/semaphore/jobs.v1alpha.proto
@@ -162,4 +162,5 @@ message CreateDebugJobRequest {
 message CreateDebugProjectRequest {
   string project_id = 1;
   int32 duration = 2; // Duration of debug jobs in minutes, defaults to 60 minutes when set to 0.
+  string machine_type = 3; // machine type to use for debugging; default: e1-standard-2
 }

--- a/semaphore/jobs.v1alpha.yml
+++ b/semaphore/jobs.v1alpha.yml
@@ -22,7 +22,7 @@ http:
     body: "*"
 
   - selector: semaphore.jobs.v1alpha.JobsApi.CreateDebugProject
-    post: /api/v1alpha/jobs/project_debug/{project_id}
+    post: /api/v1alpha/jobs/project_debug/{project_id_or_name}
     body: "*"
 
   - selector: semaphore.jobs.v1alpha.JobsApi.StopJob

--- a/semaphore/jobs.v1alpha.yml
+++ b/semaphore/jobs.v1alpha.yml
@@ -21,6 +21,10 @@ http:
     post: /api/v1alpha/jobs/{job_id}/debug
     body: "*"
 
+  - selector: semaphore.jobs.v1alpha.JobsApi.CreateDebugProject
+    post: /api/v1alpha/jobs/{job_id}/project_debug
+    body: "*"
+
   - selector: semaphore.jobs.v1alpha.JobsApi.StopJob
     post: /api/v1alpha/jobs/{job_id}/stop
     body: "*"

--- a/semaphore/jobs.v1alpha.yml
+++ b/semaphore/jobs.v1alpha.yml
@@ -22,7 +22,7 @@ http:
     body: "*"
 
   - selector: semaphore.jobs.v1alpha.JobsApi.CreateDebugProject
-    post: /api/v1alpha/jobs/{job_id}/project_debug
+    post: /api/v1alpha/jobs/project_debug/{project_id}
     body: "*"
 
   - selector: semaphore.jobs.v1alpha.JobsApi.StopJob


### PR DESCRIPTION
Currently `sem debug project` uses `CreateJob` rpc call to start a job and then get ssh key and ssh into this job, this leaves cli responsible to create the proper job, this will allow simplification of cli to just call `CreateDebugProject` and will allow for enforcing stricter rules for `CreateJob` rpc
Benefits:
- stricter rules for `CreateJob`
- simpler cli for `sem debug project [projetc_name]` (responsibility to create the job is on our internal service)